### PR TITLE
Add ZipIterator -- wrapping ZipReader in an Iterator returning ZipEntries

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,6 +1,6 @@
 use crate::{ZipEntry, ZipReader};
 
-struct ZipIterator<F, const N: usize> {
+pub struct ZipIterator<F, const N: usize> {
     file: F,
     zip_reader: ZipReader,
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,0 +1,49 @@
+use crate::{ZipEntry, ZipReader};
+
+struct ZipIterator<F, const N: usize> {
+    file: F,
+    zip_reader: ZipReader,
+}
+
+impl<F, const N: usize> ZipIterator<F, N> {
+    pub fn new(file: F) -> Self {
+        Self {
+            file,
+            zip_reader: ZipReader::default(),
+        }
+    }
+}
+
+impl<F, const N: usize> From<F> for ZipIterator<F, N>
+where
+    F: std::io::Read,
+{
+    fn from(value: F) -> Self {
+        ZipIterator::new(value)
+    }
+}
+
+impl<F, const N: usize> Iterator for ZipIterator<F, N>
+where
+    F: std::io::Read,
+{
+    type Item = ZipEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.zip_reader.take_entry() {
+                None => {
+                    let mut buf = [0u8; N];
+                    let num = self.file.read(&mut buf).unwrap();
+
+                    if num == 0 {
+                        return None;
+                    }
+
+                    self.zip_reader.update(buf[..num].to_vec().into());
+                }
+                entry => return entry,
+            }
+        }
+    }
+}

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,5 +1,6 @@
 use crate::{ZipEntry, ZipReader};
 
+/// Reads the given file in chunks of N bytes and returns one `ZipEntry` at a time
 pub struct ZipIterator<F, const N: usize> {
     file: F,
     zip_reader: ZipReader,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod tests {
     use tokio::io::AsyncReadExt;
 
     use std::{
+        fs::File,
         io::Read,
         path::{Path, PathBuf},
     };
@@ -83,5 +84,21 @@ mod tests {
             test_zip(&file.path(), 1024 * 1024).await?;
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_iter() {
+        let file = std::fs::File::open(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/readme.zip"),
+        )
+        .unwrap();
+        let zip: ZipIterator<File, 32> = file.into();
+
+        let mut entries = Vec::new();
+        for entry in zip {
+            entries.push(entry);
+        }
+
+        assert_eq!(1, entries.len());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ mod error;
 pub use self::error::*;
 mod reader;
 pub use reader::*;
+mod iterator;
+pub use iterator::*;
 
 #[cfg(test)]
 mod tests {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -330,6 +330,10 @@ impl ZipEntry {
         &self.bytes
     }
 
+    pub fn header(&self) -> &LocalFileHeader {
+        &self.header
+    }
+
     pub fn inflate(self) -> Result<DeflatedEntry, crate::Error> {
         let bytes = self.bytes;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -252,6 +252,10 @@ impl ZipReader {
         &self.entries
     }
 
+    pub fn take_entry(&mut self) -> Option<ZipEntry> {
+        self.entries.pop()
+    }
+
     pub fn drain_entries(&mut self) -> Vec<ZipEntry> {
         self.entries.drain(0..).collect()
     }


### PR DESCRIPTION
Love the crate!

For our use case, an iterator was much more ergonomic to use than the existing API. So this PR adds ZipIterator which returns one entry at a time, reading a specified number of bytes at a time from the source.